### PR TITLE
Fix batch upload after refactoring

### DIFF
--- a/src/dataloaderservices/views.py
+++ b/src/dataloaderservices/views.py
@@ -735,6 +735,9 @@ class TimeSeriesValuesApi(APIView):
         if not all(len(m) == num_measurements for m in measurement_data.values()):
             raise exceptions.ParseError("unequal number of data points")
 
+        if num_measurements == 0:
+            return Response({}, status.HTTP_201_CREATED) # vacuous but correct
+
         sampling_feature = SamplingFeature.objects.filter(sampling_feature_uuid__exact=sampling_feature).first()
         if not sampling_feature:
             raise exceptions.ParseError('Sampling Feature code does not match any existing site.')

--- a/src/dataloaderservices/views.py
+++ b/src/dataloaderservices/views.py
@@ -786,8 +786,8 @@ class TimeSeriesValuesApi(APIView):
                 # generated last in the loop
                 latest_values.append(result_values[-1])
 
-            # assume the last measurement datetime is the latest
-            set_deployment_date(sampling_feature.sampling_feature_id, measurement_datetimes[-1][0], connection)
+            # earliest measurement is the date of deployment
+            set_deployment_date(sampling_feature.sampling_feature_id, min(v[0] for v in measurement_datetimes), connection)
 
             insert_timeseries_result_values(result_values, connection)
             update_sensormeasurements(latest_values, connection)


### PR DESCRIPTION
Fixes the most important issue of multiple data points per request having been broken.

Also fixes some date sorting to correctly implement the protocol statement that "The result of sending a request with arrays of data points in a certain order shall be the same as sending an individual request for each data point in that same order (assuming the requests are sent serially and no errors are encountered)."